### PR TITLE
Remove tslib dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.2.1 (05.10.2020)
+
+Removed tslib from dependencies.
+
 ## 6.2.0 (29.09.2020)
 
 Added [base64ToUint8Array](./lib/base64-to-uint8array.ts).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@funboxteam/diamonds",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3406,11 +3406,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "tslib": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
-      "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g=="
-    },
     "tsutils": {
       "version": "3.17.1",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@funboxteam/diamonds",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "A shiny pile of typed JS helpers for everyday use",
   "scripts": {
     "lint": "eslint --cache -c .eslintrc.js --ext .ts lib",

--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
     "dist/",
     "MIGRATION.md"
   ],
-  "dependencies": {
-    "tslib": "2.0.0"
-  },
   "devDependencies": {
     "@funboxteam/eslint-config": "5.0.0",
     "@types/node": "14.0.4",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "importHelpers": true,
     "lib": ["es2017", "es7", "es6", "dom"],
     "moduleResolution": "node",
     "noEmitOnError": true,


### PR DESCRIPTION
This package depends on [tslib](https://www.npmjs.com/package/tslib), but actually it doesn't make sense, because this package doesn't have any code dependent of tslib.

So, I turned off [importHelpers](https://www.typescriptlang.org/tsconfig#importHelpers) option and removed this dependency.