### PR TITLE
Replace plain space with non-breaking space in formatPhoneNumberString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 8.0.0 (17.02.2021)
+
+Replaced plain space by non-breaking space in [formatPhoneNumberString](./lib/format-phone-number-string.ts).
+
+
 ## 7.0.0 (16.02.2021)
 
 Changed behavior of [enableBodyScroll](./lib/body-scroll.ts) & [disableBodyScroll](./lib/body-scroll.ts). 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,11 @@
 # Migrations
 
+## 7.0.0 → 8.0.0
+
+Make sure that using non-breaking space in result of [formatPhoneNumberString](./lib/format-phone-number-string.ts)
+fits well to your project.
+
+
 ## 6.6.0 → 7.0.0
 
 If your project used [enableBodyScroll](./lib/body-scroll.ts) or [disableBodyScroll](./lib/body-scroll.ts),

--- a/lib/format-phone-number-string.ts
+++ b/lib/format-phone-number-string.ts
@@ -1,3 +1,3 @@
 export default (phone: number, { prefix = '+' } = {}): string => phone
   .toString()
-  .replace(/(\d)(\d{3})(\d{3})(\d{2})(\d{2})/g, `${prefix}$1 $2 $3-$4-$5`);
+  .replace(/(\d)(\d{3})(\d{3})(\d{2})(\d{2})/g, `${prefix}$1\xa0$2\xa0$3-$4-$5`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@funboxteam/diamonds",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@funboxteam/diamonds",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "description": "A shiny pile of typed JS helpers for everyday use",
   "scripts": {
     "lint": "eslint --cache -c .eslintrc.js --ext .ts lib",


### PR DESCRIPTION
I have added space option to [formatPhoneNumberString](./lib/format-phone-number-string.js), like we have in [formatNumberString](./lib/format-number-string.js).

I think it can be useful in some cases. For example, we can replace plain space by nonbreakable space.