### PR TITLE
Support arrays in objectToQueryString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 8.1.0 (19.02.2021)
+
+Support arrays of primitive types in [objectToQueryString](./lib/object-to-query-string.ts).
+
+
 ## 8.0.0 (17.02.2021)
 
 Replaced plain space by non-breaking space in [formatPhoneNumberString](./lib/format-phone-number-string.ts).

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Converts query-string into object.
 
 ### [objectToQueryString](./lib/object-to-query-string.ts)
 
-Converts the passed object which contains primitive values into the query string. 
+Converts the passed object which contains primitive values or arrays of primitive values into the query string. 
 
 ### [omit](./lib/omit.ts)
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -246,8 +246,8 @@ getImageOrientation.call(this, image, orientation => {
 
 ### [objectToQueryString](./lib/object-to-query-string.ts)
 
-Превращает объект, в котором значения ключей представлены примитивными типами,
-в query-строку.
+Превращает объект, в котором значения ключей представлены примитивными типами или массивами
+примитивных типов, в query-строку.
 
 ### [omit](./lib/omit.ts)
 

--- a/lib/object-to-query-string.ts
+++ b/lib/object-to-query-string.ts
@@ -1,7 +1,15 @@
-type QueryStringValue = string | number | boolean;
+type QueryStringValue = string | number | boolean | (string | number | boolean)[];
 
 const join = (obj: Record<string, QueryStringValue>): string => Object.keys(obj)
-  .map(key => `${key}=${encodeURIComponent(obj[key])}`)
+  .reduce((acc: string[], key) => {
+    const value = obj[key];
+
+    if (Array.isArray(value)) {
+      return acc.concat(value.map((item) => `${key}=${encodeURIComponent(item)}`));
+    }
+
+    return acc.concat(`${key}=${encodeURIComponent(value)}`);
+  }, [])
   .join('&');
 
 export default (params: Record<string, QueryStringValue>): string => `?${join(params)}`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@funboxteam/diamonds",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@funboxteam/diamonds",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "A shiny pile of typed JS helpers for everyday use",
   "scripts": {
     "lint": "eslint --cache -c .eslintrc.js --ext .ts lib",


### PR DESCRIPTION
Added support of arrays in passed objects.

`{'foo': ['bar', 'baz']}` converts to `foo=bar&foo=baz`.