### PR TITLE
Support symbol and non-enumerable properties when comparing objects

### DIFF
--- a/lib/equals.ts
+++ b/lib/equals.ts
@@ -7,8 +7,8 @@ export default function equals(a: any, b: any): boolean {
   if (!a || !b || (typeof a !== 'object' && typeof b !== 'object')) return a === b;
   if (a.prototype !== b.prototype) return false;
 
-  const keys = Object.keys(a);
-  if (keys.length !== Object.keys(b).length) return false;
+  const keys = Reflect.ownKeys(a);
+  if (keys.length !== Reflect.ownKeys(b).length) return false;
 
   return keys.every(k => equals(a[k], b[k]));
 }


### PR DESCRIPTION
This replaces use of `Object.keys` with [`Reflect.ownKeys`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/ownKeys) which lists also symbol and non-enumerable keys.

Example:

```js
const o = {
  [Symbol.match]: true
}

Object.defineProperty(o, 'key', { value: 'example });

Object.keys(o)
// -> []

Reflect.ownKeys(o)
// -> ["key", Symbol(Symbol.match)]
```